### PR TITLE
Changes to make RHIPE work CDH5 RHEL

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -157,7 +157,7 @@
     <target name="r-build">
         <exec executable="R" failonerror="true" failifexecutionfails="true">
             <arg value="CMD"/>
-            <arg value="BUILD"/>
+            <arg value="build"/>
             <arg value="${r.package}"/>
         </exec>
 

--- a/src/main/R/extra.functions.R
+++ b/src/main/R/extra.functions.R
@@ -30,6 +30,11 @@ initPRNG <- function(seed = NULL) {
    mi
 }
 
+parseJobIDFromTracking = function(results){
+     results$jobid
+}
+
+
 #' Reads all or some lines from a text file located on the HDFS
 #' @param inp The location of the text file, interolated based on hdfs.getwd
 #' @param l the number of lines to read

--- a/src/main/R/rhErrors.R
+++ b/src/main/R/rhErrors.R
@@ -1,17 +1,33 @@
-#' Retrieves errors from a job when debug=='collect' in rhwatch
+#' Retrieves errors from a job when debug=='collect' in rhwatch or dump frames was used
 #'
-#' Retrieves errors from a job when debug=='collect' in rhwatch
-#' @param job is the result of rhwatch (when read=FALSE) or rhmr
-#' @param prefix is the prefix string of the debug files
-#' @param num.file is the number of debug files to read
+#' Retrieves errors from a job when debug=='collect' in rhwatch or the user dumped frames
+#' @param job is the result of rhwatch (when read=FALSE) or a jobid (character)
+#' @param prefix is the prefix string of the debug files (optional for dump frames)
+#' @param num.file is the number of debug files to read (doesn't apply to dump frame options)
 #' @author Saptarshi Guha
 #' @export
 rherrors <- function(job, prefix = "rhipe_debug", num.file = 1) {
-   files <- rhls(sprintf("%s/%s/", rhofolder(job), rhoptions()$rhipe_copyfile_folder))$file
+   tryCatch({
+      id <- if(is(job, 'rhwatch')) job[[1]]$jobid ## if rhwatch succeeds
+             else  if(is(job, 'list') && is(job[[2]], "rhmr")) job[[1]]$jobid ## if job fails
+	     else  if(is(job,"character")) job ## you just provide a job id
+      x1 <- rhls(sprintf("%s/map-reduce-error%s", rhoptions()$HADOOP.TMP.FOLDER,id),rec=TRUE)
+      m1 = nrow(x1)
+} ,error=function(e) 0)
+   if(m1>0){
+      ## user used the dump file option
+      return(x1[x1$size>0,])
+   }
+   files <- tryCatch(rhls(sprintf("%s/%s/", rhofolder(job), rhoptions()$rhipe_copyfile_folder))$file, error=function(e) NULL)
+   if(is.null(files)) {
+     warning( sprintf("No Errors for this location: %s",(sprintf("%s", rhofolder(job)))))
+     return(NULL)
+  }
    files <- files[grepl(prefix, files)][1:num.file]
    y <- new.env()
    unlist(lapply(files, function(r) {
       rhload(r, envir = y)
       y$rhipe.errors
    }), recursive = FALSE)
-} 
+
+}

--- a/src/main/R/rhJobInfo.R
+++ b/src/main/R/rhJobInfo.R
@@ -15,9 +15,7 @@ rhJobInfo <- function(job) {
       job <- job[[1]]
       id <- job[["job.id"]]
    } else if (is(job, "rhwatch")) {
-      x <- gregexpr("jobid=", job[[1]]$tracking)
-      st <- x[[1]] + attr(x[[1]], "match.length")
-      id <- substring(job[[1]]$tracking, st, 1000000L)
+	 id = parseJobIDFromTracking(job[[1]])
    }
    a <- fu$getDetailedInfoForJob(id)
    a <- rhuz(a)

--- a/src/main/R/rhstatus.R
+++ b/src/main/R/rhstatus.R
@@ -45,9 +45,7 @@ rhstatus <- function(job, mon.sec = 5, autokill = TRUE, showErrors = TRUE, verbo
       job <- job[[1]]
       id <- job[["job.id"]]
    } else if (is(job, "rhwatch")) {
-      x <- gregexpr("jobid=", job[[1]]$tracking)
-      st <- x[[1]] + attr(x[[1]], "match.length")
-      id <- substring(job[[1]]$tracking, st, 1000000L)
+      id = parseJobIDFromTracking(job[[1]])
    }
    if (mon.sec == Inf) {
       result <- rhoptions()$server$rhjoin(id, TRUE)
@@ -223,7 +221,7 @@ rhstatus <- function(job, mon.sec = 5, autokill = TRUE, showErrors = TRUE, verbo
    })
    return(list(state = state, duration = duration, progress = d, warnings = wrns, 
       counters = ro2, rerrors = haveRError, errors = errs, jobname = result[[9]], 
-      tracking = result[[8]], config = result[[10]]))
+      tracking = result[[8]], config = result[[10]],jobid  = result[[11]]  ))
 }
 
 

--- a/src/main/R/rhwatch.R
+++ b/src/main/R/rhwatch.R
@@ -325,7 +325,8 @@ rhwatch <- function(map = NULL, reduce = NULL, combiner = FALSE, setup = NULL,
               })
             }, seq_along(map.values), map.keys, map.values, SIMPLIFY = FALSE)
             .(AFTER)
-         }, list(BEFORE = FIX(l$before), AFTER = FIX(l$after), REPLACE = FIX(l$replace))))
+             }, list(BEFORE = FIX(l$before), AFTER = FIX(l$after), REPLACE = FIX(l$replace))))
+         
          environment(newm) <- .BaseNamespaceEnv
          job[[1]]$rhipe_map <- rawToChar(serialize(newm, NULL, ascii = TRUE))
       } else if (is(m, "rhmr-map2")) {
@@ -338,13 +339,11 @@ rhwatch <- function(map = NULL, reduce = NULL, combiner = FALSE, setup = NULL,
               })
             }, map.keys, map.values, SIMPLIFY = FALSE)
          })
+         
          environment(newm) <- .BaseNamespaceEnv
          job[[1]]$rhipe_map <- rawToChar(serialize(newm, NULL, ascii = TRUE))
       }
-      
       ## Has the user given one?
-      if (!is.list(debug) || (is.list(debug) && is.null(debug$map)) )
-         stop("debug should be list with a sublist named 'map'")
       if (is.list(debug) && !is.null(debug$map)) {
          if (!is.null(debug$map$setup)) 
             setup <- debug$map$setup
@@ -414,10 +413,8 @@ rhwatch.runner <- function(job, mon.sec = 5, readback = TRUE, debug = NULL, ...)
       # if rhoption write.job.info is TRUE, then write it to _rh_meta
       if (results$state == "SUCCEEDED" && rhoptions()$write.job.info) {
          # get job id
-         x <- gregexpr("jobid=", results$tracking)
-         st <- x[[1]] + attr(x[[1]], "match.length")
-         id <- substring(results$tracking, st, 1000000L)
-         
+	 id = parseJobIDFromTracking(results)
+	          
          jobData <- list(results = results, jobConf = job, jobInfo = rhJobInfo(id))
          rhsave(jobData, file = paste(ofolder, "/_rh_meta/jobData.Rdata", sep = ""))
       }

--- a/src/main/java/org/godhuli/rhipe/FileUtils.java
+++ b/src/main/java/org/godhuli/rhipe/FileUtils.java
@@ -431,16 +431,17 @@ public class FileUtils {
 
         final REXP.Builder theVals = REXP.newBuilder();
         theVals.setRclass(REXP.RClass.LIST);
-        theVals.addRexpValue(RObjects.makeStringVector(new String[]{jobss}));
-        theVals.addRexpValue(RObjects.buildDoubleVector(new double[]{dura}));
-        theVals.addRexpValue(RObjects.buildDoubleVector(new double[]{(double) mapprog, (double) reduprog}));
-        theVals.addRexpValue(RObjects.buildIntVector(new int[]{totalmaps, mappending, maprunning, mapcomp, mapkilled, mapafails, mapakilled}));
-        theVals.addRexpValue(RObjects.buildIntVector(new int[]{totalreds, redpending, redrunning, redcomp, redkilled, reduceafails, reduceakilled}));
-        theVals.addRexpValue(ro);
-        theVals.addRexpValue(errcontainer);
-        theVals.addRexpValue(RObjects.makeStringVector(rj.getTrackingURL()));
-        theVals.addRexpValue(RObjects.makeStringVector(new String[]{jobname}));
-        theVals.addRexpValue(RObjects.makeStringVector(new String[]{jobfile}));
+        theVals.addRexpValue(RObjects.makeStringVector(new String[]{jobss})); //1
+        theVals.addRexpValue(RObjects.buildDoubleVector(new double[]{dura})); //2
+        theVals.addRexpValue(RObjects.buildDoubleVector(new double[]{(double) mapprog, (double) reduprog})); //3
+        theVals.addRexpValue(RObjects.buildIntVector(new int[]{totalmaps, mappending, maprunning, mapcomp, mapkilled, mapafails, mapakilled})); //4
+        theVals.addRexpValue(RObjects.buildIntVector(new int[]{totalreds, redpending, redrunning, redcomp, redkilled, reduceafails, reduceakilled})); //5
+        theVals.addRexpValue(ro); //6
+        theVals.addRexpValue(errcontainer); //7
+        theVals.addRexpValue(RObjects.makeStringVector(rj.getTrackingURL())); //8
+        theVals.addRexpValue(RObjects.makeStringVector(new String[]{jobname})); //9
+        theVals.addRexpValue(RObjects.makeStringVector(new String[]{jobfile})); //10
+	theVals.addRexpValue(RObjects.makeStringVector(rj.getID().toString())); //11
         return (theVals.build());
     }
 


### PR DESCRIPTION
1. Changed build.xml to use R CMD build (failed on Linux/RHEL)
2. rherrors can read output of rhwatch(..., read=FALSE) to read the errors folder using the new dump frames options
3. rhJobInfo, rhstatus and rhwatch correctly get the jobid (uses the Java MapReduce API)
4. rhstatus (inside FileUtils) to return jobid (no need to use regex parsing)