### PR TITLE
Updated the code to handle nulls in input text files using modified utf-8

### DIFF
--- a/src/main/C/message.cc
+++ b/src/main/C/message.cc
@@ -4,6 +4,11 @@
 
 using namespace std;
 
+#if R_VERSION < R_Version(2,7,0)                                                                                                                                                                                                          
+#define mkCharUTF8(X) Rf_mkChar(X)
+#else                                                                                                                                                                                                                                     
+#define mkCharUTF8(X) Rf_mkCharCE(X, CE_UTF8)
+#endif  
 
 SEXP rexpress(const char* cmd)
 {
@@ -82,7 +87,7 @@ SEXP rexpToSexp(const REXP& rexp){
       	if (st.isna())
       	  SET_STRING_ELT(s,i,R_NaString);
       	else{
-	  SEXP y=  Rf_mkChar(st.strval().c_str());
+	  SEXP y=  mkCharUTF8(st.strval().c_str());
       	  SET_STRING_ELT(s,i,y);
 	}
       }
@@ -103,22 +108,6 @@ SEXP rexpToSexp(const REXP& rexp){
     {
       for (int j=0; j<atlength; j++)
   	{
-	  // const char *nameofatt = rexp.attrname(j).c_str();
-	  // if(strcmp(nameofatt,"names")==0 && typ!=VECSXP) continue;
-	  // if(strcmp(nameofatt,"names")==0 && typ==VECSXP){
-	  //   SEXP v ;
-	  //   PROTECT(v= message2rexp(rexp.attrvalue(j)));
-	  //   if(!Rf_isNull(v)) Rf_setAttrib(s,Rf_install(nameofatt), v );
-	  //   UNPROTECT(1);
-	  // }
-//   	  SEXP n=Rf_mkString(nameofatt);
-	  // SEXP v ;
-	  // PROTECT(v= message2rexp(rexp.attrvalue(j)));
-  	  // if(!Rf_isNull(v)) Rf_setAttrib(s,Rf_install(nameofatt), v );
-	  // UNPROTECT(1);
-
-	  // TEST TEST TEST TEST COULD FAILS
-	  // REVERT TO PREVIOUS CODE
 	  Rf_setAttrib(s,
 	  	       Rf_install(rexp.attrname(j).c_str()), 
 	  	       rexpToSexp(rexp.attrvalue(j)));

--- a/src/main/R/rhfmt.R
+++ b/src/main/R/rhfmt.R
@@ -138,13 +138,14 @@ sequenceio <- function(folders, recordsAsText = FALSE) {
 }
 
 textio <- function(folders, nline = NULL, writeKey = TRUE, field.sep = " ", kv.sep = "\t", 
-   eol = "\r\n", stringquote = "") {
+   eol = "\r\n", stringquote = "",encode.null=TRUE) {
    folders <- eval(folders)
    writeKey <- eval(writeKey)
    field.sep <- eval(field.sep)
    kv.sep <- eval(kv.sep)
    eol <- eval(eol)
    stringquote <- eval(stringquote)
+   encode.null <-eval(encode.null)
    function(lines, direction, caller) {
       if (direction == "input") {
          folders <- Rhipe:::folder.handler(folders)
@@ -161,7 +162,7 @@ textio <- function(folders, nline = NULL, writeKey = TRUE, field.sep = " ", kv.s
          }
          lines$rhipe_inputformat_keyclass <- "org.godhuli.rhipe.RHNumeric"
          lines$rhipe_inputformat_valueclass <- "org.godhuli.rhipe.RHText"
-         
+         lines$rhipe_textinputformat_encode_null <- as.character(as.logical(encode.null))
          if (is.null(lines$param.temp.file)) {
             linesToTable <- Rhipe:::linesToTable
             environment(linesToTable) <- .BaseNamespaceEnv

--- a/src/main/java/org/godhuli/rhipe/RHMRHelper.java
+++ b/src/main/java/org/godhuli/rhipe/RHMRHelper.java
@@ -50,7 +50,7 @@ public class RHMRHelper {
     private static final long REPORTER_OUT_DELAY = 10 * 1000L;
     private static final long REPORTER_ERR_DELAY = 10 * 1000L;
     private static final String ERROR_OUTPUT_DIR = "map-reduce-error";
-
+    protected static boolean ENCODE_NULLS_IN_TEXT = false;
     protected static int PARTITION_START = 0, PARTITION_END = 0;
     private boolean copyFile;
     private Environment env_;
@@ -147,6 +147,12 @@ public class RHMRHelper {
                 squote = "";
             }
 
+	    String encodenull =cfg.get("rhipe_textinputformat_encode_null");
+	    if(encodenull == null || encodenull.equals("TRUE")){
+		RHMRHelper.ENCODE_NULLS_IN_TEXT=true;
+	    }else{
+		RHMRHelper.ENCODE_NULLS_IN_TEXT=false;
+	    }
             REXPHelper.setFieldSep(cfg.get("mapred.field.separator", " "));
             REXPHelper.setStringQuote(squote);
 


### PR DESCRIPTION
.....) takes an option rhipe_textinputformat_encode_null (default is TRUE) which will encode null as modified UTF-8 (see

http://stackoverflow.com/questions/7921016/what-does-it-mean-to-say-java-modified-utf-8-encoding ). This adds a slight cost to processing input text files(since the code has to go through the string to count the number of nulls and replace them). That said, to turn if off, call rhfmt(type='text',folder=, rhipe_textinputformat_encode_null=FALSE).

RHMRHelper reads the new option (rhipe_textinputformat_encode_null)
RHText.java can encode both ways (the usual or modified UTF-8, the latter is costlier)
rhfmt.R allows the user to specify it
message.cc uses UTF-8 encoding