### PR TITLE
Added Serialization for Simple Environments 

### DIFF
--- a/src/main/C/display.cc
+++ b/src/main/C/display.cc
@@ -297,12 +297,10 @@ extern "C" {
     static bool once = false;
     static std::string *ks;
     static std::string *vs;
-    static uint32_t combiner_count;
     uint32_t ksize=0,vsize=0;
     if(!once){
       ks = new std::string();
       vs = new std::string();
-      combiner_count = 0;
       once = true;
     }
     ks->clear();vs->clear();

--- a/src/main/C/fileio.cc
+++ b/src/main/C/fileio.cc
@@ -140,10 +140,7 @@ void writeUInt32(FILE* fout, uint32_t value){
 
 
 // readUInt32
-uint32_t readUInt32(FILE* fin){
-
-
-}
+//uint32_t readUInt32(FILE* fin){}
 
 
 

--- a/src/main/C/mapreduce.cc
+++ b/src/main/C/mapreduce.cc
@@ -229,7 +229,7 @@ int mainMapperLoop(FILE* fin){
 
 	  int32_t type=0;
 	  int32_t buffer_size=0;
-	  SEXP runner1,runner2,cleaner,kvector,vvector;
+	  SEXP runner1,runner2,kvector,vvector;
 	  char * mapbustr;
 	  int protect= 0;
 	  int32_t  max_bytes_to_read = 0;
@@ -422,7 +422,7 @@ SEXP execMapReduce() {
 		return(R_NilValue);
 	}
 #endif
-	int uid = geteuid();
+	//int uid = geteuid();
 #ifdef RHIPEDEBUG
 	char fn[1024];
 	char *logfile=NULL;
@@ -466,7 +466,7 @@ SEXP execMapReduce() {
 
 	LOGG(10,"STD{IN,OUT,ERR}  in binary \n");
 
-	int ret = 0;
+	//int ret = 0;
 #ifdef USETIMER
 	struct timeval tms;
 	long int bstart, bend;

--- a/src/main/C/ream.h
+++ b/src/main/C/ream.h
@@ -29,8 +29,8 @@ using namespace std;
 
 #include <Rversion.h>
 #include <R.h>
-#include <Rdefines.h>
-/* #include <Rinternals.h> */
+//#include <Rdefines.h>
+#include <Rinternals.h>
 #include <Rembedded.h>
 #include <R_ext/Boolean.h>
 #include <R_ext/Parse.h>

--- a/src/main/C/reducer.cc
+++ b/src/main/C/reducer.cc
@@ -29,6 +29,7 @@ const int reducer_run(void){
   }
   if ((redbustr=getenv("rhipe_reduce_bytes_read")))
     REDBUFFER_MAXBYTES= (unsigned int)strtol(redbustr,NULL,10);
+  //gcc warns about the above being possibly not initialized, but R will make it so. Or rather RHIPE will make it so
 
   PROTECT(prekey0=rexpress(REDUCEPREKEY));
   PROTECT(prekey=Rf_lang2(Rf_install("eval"),prekey0));

--- a/src/main/C/rexp.pb.cc
+++ b/src/main/C/rexp.pb.cc
@@ -23,6 +23,9 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
   REXP_reflection_ = NULL;
 const ::google::protobuf::EnumDescriptor* REXP_RClass_descriptor_ = NULL;
 const ::google::protobuf::EnumDescriptor* REXP_RBOOLEAN_descriptor_ = NULL;
+const ::google::protobuf::Descriptor* ENV_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  ENV_reflection_ = NULL;
 const ::google::protobuf::Descriptor* STRING_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   STRING_reflection_ = NULL;
@@ -40,7 +43,7 @@ void protobuf_AssignDesc_rexp_2eproto() {
       "rexp.proto");
   GOOGLE_CHECK(file != NULL);
   REXP_descriptor_ = file->message_type(0);
-  static const int REXP_offsets_[10] = {
+  static const int REXP_offsets_[11] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(REXP, rclass_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(REXP, realvalue_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(REXP, intvalue_),
@@ -51,6 +54,7 @@ void protobuf_AssignDesc_rexp_2eproto() {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(REXP, rexpvalue_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(REXP, attrname_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(REXP, attrvalue_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(REXP, envvalue_),
   };
   REXP_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -65,7 +69,23 @@ void protobuf_AssignDesc_rexp_2eproto() {
       sizeof(REXP));
   REXP_RClass_descriptor_ = REXP_descriptor_->enum_type(0);
   REXP_RBOOLEAN_descriptor_ = REXP_descriptor_->enum_type(1);
-  STRING_descriptor_ = file->message_type(1);
+  ENV_descriptor_ = file->message_type(1);
+  static const int ENV_offsets_[2] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ENV, key_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ENV, value_),
+  };
+  ENV_reflection_ =
+    new ::google::protobuf::internal::GeneratedMessageReflection(
+      ENV_descriptor_,
+      ENV::default_instance_,
+      ENV_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ENV, _has_bits_[0]),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(ENV, _unknown_fields_),
+      -1,
+      ::google::protobuf::DescriptorPool::generated_pool(),
+      ::google::protobuf::MessageFactory::generated_factory(),
+      sizeof(ENV));
+  STRING_descriptor_ = file->message_type(2);
   static const int STRING_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(STRING, strval_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(STRING, isna_),
@@ -81,7 +101,7 @@ void protobuf_AssignDesc_rexp_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(STRING));
-  CMPLX_descriptor_ = file->message_type(2);
+  CMPLX_descriptor_ = file->message_type(3);
   static const int CMPLX_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(CMPLX, real_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(CMPLX, imag_),
@@ -112,6 +132,8 @@ void protobuf_RegisterTypes(const ::std::string&) {
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     REXP_descriptor_, &REXP::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+    ENV_descriptor_, &ENV::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     STRING_descriptor_, &STRING::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
     CMPLX_descriptor_, &CMPLX::default_instance());
@@ -122,6 +144,8 @@ void protobuf_RegisterTypes(const ::std::string&) {
 void protobuf_ShutdownFile_rexp_2eproto() {
   delete REXP::default_instance_;
   delete REXP_reflection_;
+  delete ENV::default_instance_;
+  delete ENV_reflection_;
   delete STRING::default_instance_;
   delete STRING_reflection_;
   delete CMPLX::default_instance_;
@@ -135,27 +159,30 @@ void protobuf_AddDesc_rexp_2eproto() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-    "\n\nrexp.proto\"\274\003\n\004REXP\022\034\n\006rclass\030\001 \002(\0162\014."
+    "\n\nrexp.proto\"\276\003\n\004REXP\022\034\n\006rclass\030\001 \002(\0162\014."
     "REXP.RClass\022\025\n\trealValue\030\002 \003(\001B\002\020\001\022\024\n\010in"
     "tValue\030\003 \003(\021B\002\020\001\022$\n\014booleanValue\030\004 \003(\0162\016"
     ".REXP.RBOOLEAN\022\034\n\013stringValue\030\005 \003(\0132\007.ST"
     "RING\022\020\n\010rawValue\030\006 \001(\014\022\034\n\014complexValue\030\007"
     " \003(\0132\006.CMPLX\022\030\n\trexpValue\030\010 \003(\0132\005.REXP\022\020"
     "\n\010attrName\030\013 \003(\t\022\030\n\tattrValue\030\014 \003(\0132\005.RE"
-    "XP\"\214\001\n\006RClass\022\n\n\006STRING\020\000\022\007\n\003RAW\020\001\022\010\n\004RE"
-    "AL\020\002\022\013\n\007COMPLEX\020\003\022\013\n\007INTEGER\020\004\022\010\n\004LIST\020\005"
-    "\022\013\n\007LOGICAL\020\006\022\014\n\010NULLTYPE\020\007\022\t\n\005REAL1\020\010\022\014"
-    "\n\010INTEGER1\020\n\022\013\n\007STRING1\020\t\" \n\010RBOOLEAN\022\005\n"
-    "\001F\020\000\022\005\n\001T\020\001\022\006\n\002NA\020\002\"-\n\006STRING\022\016\n\006strval\030"
-    "\001 \001(\t\022\023\n\004isNA\030\002 \001(\010:\005false\"&\n\005CMPLX\022\017\n\004r"
-    "eal\030\001 \001(\001:\0010\022\014\n\004imag\030\002 \002(\001B\037\n\021org.godhul"
-    "i.rhipeB\nREXPProtos", 579);
+    "XP\022\026\n\010envValue\030\r \003(\0132\004.ENV\"w\n\006RClass\022\n\n\006"
+    "STRING\020\000\022\007\n\003RAW\020\001\022\010\n\004REAL\020\002\022\013\n\007COMPLEX\020\003"
+    "\022\013\n\007INTEGER\020\004\022\010\n\004LIST\020\005\022\013\n\007LOGICAL\020\006\022\014\n\010"
+    "NULLTYPE\020\007\022\017\n\013ENVIRONMENT\020\010\" \n\010RBOOLEAN\022"
+    "\005\n\001F\020\000\022\005\n\001T\020\001\022\006\n\002NA\020\002\"(\n\003ENV\022\013\n\003key\030\001 \001("
+    "\t\022\024\n\005value\030\002 \001(\0132\005.REXP\"-\n\006STRING\022\016\n\006str"
+    "val\030\001 \001(\t\022\023\n\004isNA\030\002 \001(\010:\005false\"&\n\005CMPLX\022"
+    "\017\n\004real\030\001 \001(\001:\0010\022\014\n\004imag\030\002 \002(\001B\037\n\021org.go"
+    "dhuli.rhipeB\nREXPProtos", 623);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "rexp.proto", &protobuf_RegisterTypes);
   REXP::default_instance_ = new REXP();
+  ENV::default_instance_ = new ENV();
   STRING::default_instance_ = new STRING();
   CMPLX::default_instance_ = new CMPLX();
   REXP::default_instance_->InitAsDefaultInstance();
+  ENV::default_instance_->InitAsDefaultInstance();
   STRING::default_instance_->InitAsDefaultInstance();
   CMPLX::default_instance_->InitAsDefaultInstance();
   ::google::protobuf::internal::OnShutdown(&protobuf_ShutdownFile_rexp_2eproto);
@@ -185,8 +212,6 @@ bool REXP_RClass_IsValid(int value) {
     case 6:
     case 7:
     case 8:
-    case 9:
-    case 10:
       return true;
     default:
       return false;
@@ -202,9 +227,7 @@ const REXP_RClass REXP::INTEGER;
 const REXP_RClass REXP::LIST;
 const REXP_RClass REXP::LOGICAL;
 const REXP_RClass REXP::NULLTYPE;
-const REXP_RClass REXP::REAL1;
-const REXP_RClass REXP::INTEGER1;
-const REXP_RClass REXP::STRING1;
+const REXP_RClass REXP::ENVIRONMENT;
 const REXP_RClass REXP::RClass_MIN;
 const REXP_RClass REXP::RClass_MAX;
 const int REXP::RClass_ARRAYSIZE;
@@ -243,6 +266,7 @@ const int REXP::kComplexValueFieldNumber;
 const int REXP::kRexpValueFieldNumber;
 const int REXP::kAttrNameFieldNumber;
 const int REXP::kAttrValueFieldNumber;
+const int REXP::kEnvValueFieldNumber;
 #endif  // !_MSC_VER
 
 REXP::REXP()
@@ -316,6 +340,7 @@ void REXP::Clear() {
   rexpvalue_.Clear();
   attrname_.Clear();
   attrvalue_.Clear();
+  envvalue_.Clear();
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
   mutable_unknown_fields()->Clear();
 }
@@ -506,6 +531,21 @@ bool REXP::MergePartialFromCodedStream(
           goto handle_uninterpreted;
         }
         if (input->ExpectTag(98)) goto parse_attrValue;
+        if (input->ExpectTag(106)) goto parse_envValue;
+        break;
+      }
+
+      // repeated .ENV envValue = 13;
+      case 13: {
+        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_LENGTH_DELIMITED) {
+         parse_envValue:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+                input, add_envvalue()));
+        } else {
+          goto handle_uninterpreted;
+        }
+        if (input->ExpectTag(106)) goto parse_envValue;
         if (input->ExpectAtEnd()) return true;
         break;
       }
@@ -599,6 +639,12 @@ void REXP::SerializeWithCachedSizes(
       12, this->attrvalue(i), output);
   }
 
+  // repeated .ENV envValue = 13;
+  for (int i = 0; i < this->envvalue_size(); i++) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      13, this->envvalue(i), output);
+  }
+
   if (!unknown_fields().empty()) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         unknown_fields(), output);
@@ -689,6 +735,13 @@ void REXP::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
         12, this->attrvalue(i), target);
+  }
+
+  // repeated .ENV envValue = 13;
+  for (int i = 0; i < this->envvalue_size(); i++) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        13, this->envvalue(i), target);
   }
 
   if (!unknown_fields().empty()) {
@@ -796,6 +849,14 @@ int REXP::ByteSize() const {
         this->attrvalue(i));
   }
 
+  // repeated .ENV envValue = 13;
+  total_size += 1 * this->envvalue_size();
+  for (int i = 0; i < this->envvalue_size(); i++) {
+    total_size +=
+      ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+        this->envvalue(i));
+  }
+
   if (!unknown_fields().empty()) {
     total_size +=
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
@@ -829,6 +890,7 @@ void REXP::MergeFrom(const REXP& from) {
   rexpvalue_.MergeFrom(from.rexpvalue_);
   attrname_.MergeFrom(from.attrname_);
   attrvalue_.MergeFrom(from.attrvalue_);
+  envvalue_.MergeFrom(from.envvalue_);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
     if (from.has_rclass()) {
       set_rclass(from.rclass());
@@ -864,6 +926,9 @@ bool REXP::IsInitialized() const {
   for (int i = 0; i < attrvalue_size(); i++) {
     if (!this->attrvalue(i).IsInitialized()) return false;
   }
+  for (int i = 0; i < envvalue_size(); i++) {
+    if (!this->envvalue(i).IsInitialized()) return false;
+  }
   return true;
 }
 
@@ -879,6 +944,7 @@ void REXP::Swap(REXP* other) {
     rexpvalue_.Swap(&other->rexpvalue_);
     attrname_.Swap(&other->attrname_);
     attrvalue_.Swap(&other->attrvalue_);
+    envvalue_.Swap(&other->envvalue_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);
@@ -890,6 +956,279 @@ void REXP::Swap(REXP* other) {
   ::google::protobuf::Metadata metadata;
   metadata.descriptor = REXP_descriptor_;
   metadata.reflection = REXP_reflection_;
+  return metadata;
+}
+
+
+// ===================================================================
+
+#ifndef _MSC_VER
+const int ENV::kKeyFieldNumber;
+const int ENV::kValueFieldNumber;
+#endif  // !_MSC_VER
+
+ENV::ENV()
+  : ::google::protobuf::Message() {
+  SharedCtor();
+}
+
+void ENV::InitAsDefaultInstance() {
+  value_ = const_cast< ::REXP*>(&::REXP::default_instance());
+}
+
+ENV::ENV(const ENV& from)
+  : ::google::protobuf::Message() {
+  SharedCtor();
+  MergeFrom(from);
+}
+
+void ENV::SharedCtor() {
+  _cached_size_ = 0;
+  key_ = const_cast< ::std::string*>(&::google::protobuf::internal::kEmptyString);
+  value_ = NULL;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+ENV::~ENV() {
+  SharedDtor();
+}
+
+void ENV::SharedDtor() {
+  if (key_ != &::google::protobuf::internal::kEmptyString) {
+    delete key_;
+  }
+  if (this != default_instance_) {
+    delete value_;
+  }
+}
+
+void ENV::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* ENV::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return ENV_descriptor_;
+}
+
+const ENV& ENV::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_rexp_2eproto();
+  return *default_instance_;
+}
+
+ENV* ENV::default_instance_ = NULL;
+
+ENV* ENV::New() const {
+  return new ENV;
+}
+
+void ENV::Clear() {
+  if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (has_key()) {
+      if (key_ != &::google::protobuf::internal::kEmptyString) {
+        key_->clear();
+      }
+    }
+    if (has_value()) {
+      if (value_ != NULL) value_->::REXP::Clear();
+    }
+  }
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  mutable_unknown_fields()->Clear();
+}
+
+bool ENV::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) return false
+  ::google::protobuf::uint32 tag;
+  while ((tag = input->ReadTag()) != 0) {
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional string key = 1;
+      case 1: {
+        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_LENGTH_DELIMITED) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_key()));
+          ::google::protobuf::internal::WireFormat::VerifyUTF8String(
+            this->key().data(), this->key().length(),
+            ::google::protobuf::internal::WireFormat::PARSE);
+        } else {
+          goto handle_uninterpreted;
+        }
+        if (input->ExpectTag(18)) goto parse_value;
+        break;
+      }
+
+      // optional .REXP value = 2;
+      case 2: {
+        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_LENGTH_DELIMITED) {
+         parse_value:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_value()));
+        } else {
+          goto handle_uninterpreted;
+        }
+        if (input->ExpectAtEnd()) return true;
+        break;
+      }
+
+      default: {
+      handle_uninterpreted:
+        if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          return true;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+  return true;
+#undef DO_
+}
+
+void ENV::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // optional string key = 1;
+  if (has_key()) {
+    ::google::protobuf::internal::WireFormat::VerifyUTF8String(
+      this->key().data(), this->key().length(),
+      ::google::protobuf::internal::WireFormat::SERIALIZE);
+    ::google::protobuf::internal::WireFormatLite::WriteString(
+      1, this->key(), output);
+  }
+
+  // optional .REXP value = 2;
+  if (has_value()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      2, this->value(), output);
+  }
+
+  if (!unknown_fields().empty()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+}
+
+::google::protobuf::uint8* ENV::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // optional string key = 1;
+  if (has_key()) {
+    ::google::protobuf::internal::WireFormat::VerifyUTF8String(
+      this->key().data(), this->key().length(),
+      ::google::protobuf::internal::WireFormat::SERIALIZE);
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        1, this->key(), target);
+  }
+
+  // optional .REXP value = 2;
+  if (has_value()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        2, this->value(), target);
+  }
+
+  if (!unknown_fields().empty()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  return target;
+}
+
+int ENV::ByteSize() const {
+  int total_size = 0;
+
+  if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    // optional string key = 1;
+    if (has_key()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::StringSize(
+          this->key());
+    }
+
+    // optional .REXP value = 2;
+    if (has_value()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          this->value());
+    }
+
+  }
+  if (!unknown_fields().empty()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void ENV::MergeFrom(const ::google::protobuf::Message& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  const ENV* source =
+    ::google::protobuf::internal::dynamic_cast_if_available<const ENV*>(
+      &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void ENV::MergeFrom(const ENV& from) {
+  GOOGLE_CHECK_NE(&from, this);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_key()) {
+      set_key(from.key());
+    }
+    if (from.has_value()) {
+      mutable_value()->::REXP::MergeFrom(from.value());
+    }
+  }
+  mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+}
+
+void ENV::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ENV::CopyFrom(const ENV& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ENV::IsInitialized() const {
+
+  if (has_value()) {
+    if (!this->value().IsInitialized()) return false;
+  }
+  return true;
+}
+
+void ENV::Swap(ENV* other) {
+  if (other != this) {
+    std::swap(key_, other->key_);
+    std::swap(value_, other->value_);
+    std::swap(_has_bits_[0], other->_has_bits_[0]);
+    _unknown_fields_.Swap(&other->_unknown_fields_);
+    std::swap(_cached_size_, other->_cached_size_);
+  }
+}
+
+::google::protobuf::Metadata ENV::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = ENV_descriptor_;
+  metadata.reflection = ENV_reflection_;
   return metadata;
 }
 

--- a/src/main/C/rexp.pb.h
+++ b/src/main/C/rexp.pb.h
@@ -33,6 +33,7 @@ void protobuf_AssignDesc_rexp_2eproto();
 void protobuf_ShutdownFile_rexp_2eproto();
 
 class REXP;
+class ENV;
 class STRING;
 class CMPLX;
 
@@ -45,13 +46,11 @@ enum REXP_RClass {
   REXP_RClass_LIST = 5,
   REXP_RClass_LOGICAL = 6,
   REXP_RClass_NULLTYPE = 7,
-  REXP_RClass_REAL1 = 8,
-  REXP_RClass_INTEGER1 = 10,
-  REXP_RClass_STRING1 = 9
+  REXP_RClass_ENVIRONMENT = 8
 };
 bool REXP_RClass_IsValid(int value);
 const REXP_RClass REXP_RClass_RClass_MIN = REXP_RClass_STRING;
-const REXP_RClass REXP_RClass_RClass_MAX = REXP_RClass_INTEGER1;
+const REXP_RClass REXP_RClass_RClass_MAX = REXP_RClass_ENVIRONMENT;
 const int REXP_RClass_RClass_ARRAYSIZE = REXP_RClass_RClass_MAX + 1;
 
 const ::google::protobuf::EnumDescriptor* REXP_RClass_descriptor();
@@ -147,9 +146,7 @@ class REXP : public ::google::protobuf::Message {
   static const RClass LIST = REXP_RClass_LIST;
   static const RClass LOGICAL = REXP_RClass_LOGICAL;
   static const RClass NULLTYPE = REXP_RClass_NULLTYPE;
-  static const RClass REAL1 = REXP_RClass_REAL1;
-  static const RClass INTEGER1 = REXP_RClass_INTEGER1;
-  static const RClass STRING1 = REXP_RClass_STRING1;
+  static const RClass ENVIRONMENT = REXP_RClass_ENVIRONMENT;
   static inline bool RClass_IsValid(int value) {
     return REXP_RClass_IsValid(value);
   }
@@ -315,6 +312,18 @@ class REXP : public ::google::protobuf::Message {
   inline ::google::protobuf::RepeatedPtrField< ::REXP >*
       mutable_attrvalue();
 
+  // repeated .ENV envValue = 13;
+  inline int envvalue_size() const;
+  inline void clear_envvalue();
+  static const int kEnvValueFieldNumber = 13;
+  inline const ::ENV& envvalue(int index) const;
+  inline ::ENV* mutable_envvalue(int index);
+  inline ::ENV* add_envvalue();
+  inline const ::google::protobuf::RepeatedPtrField< ::ENV >&
+      envvalue() const;
+  inline ::google::protobuf::RepeatedPtrField< ::ENV >*
+      mutable_envvalue();
+
   // @@protoc_insertion_point(class_scope:REXP)
  private:
   inline void set_has_rclass();
@@ -335,10 +344,11 @@ class REXP : public ::google::protobuf::Message {
   ::google::protobuf::RepeatedPtrField< ::REXP > rexpvalue_;
   ::google::protobuf::RepeatedPtrField< ::std::string> attrname_;
   ::google::protobuf::RepeatedPtrField< ::REXP > attrvalue_;
+  ::google::protobuf::RepeatedPtrField< ::ENV > envvalue_;
   int rclass_;
 
   mutable int _cached_size_;
-  ::google::protobuf::uint32 _has_bits_[(10 + 31) / 32];
+  ::google::protobuf::uint32 _has_bits_[(11 + 31) / 32];
 
   friend void  protobuf_AddDesc_rexp_2eproto();
   friend void protobuf_AssignDesc_rexp_2eproto();
@@ -346,6 +356,105 @@ class REXP : public ::google::protobuf::Message {
 
   void InitAsDefaultInstance();
   static REXP* default_instance_;
+};
+// -------------------------------------------------------------------
+
+class ENV : public ::google::protobuf::Message {
+ public:
+  ENV();
+  virtual ~ENV();
+
+  ENV(const ENV& from);
+
+  inline ENV& operator=(const ENV& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _unknown_fields_;
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return &_unknown_fields_;
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const ENV& default_instance();
+
+  void Swap(ENV* other);
+
+  // implements Message ----------------------------------------------
+
+  ENV* New() const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const ENV& from);
+  void MergeFrom(const ENV& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional string key = 1;
+  inline bool has_key() const;
+  inline void clear_key();
+  static const int kKeyFieldNumber = 1;
+  inline const ::std::string& key() const;
+  inline void set_key(const ::std::string& value);
+  inline void set_key(const char* value);
+  inline void set_key(const char* value, size_t size);
+  inline ::std::string* mutable_key();
+  inline ::std::string* release_key();
+  inline void set_allocated_key(::std::string* key);
+
+  // optional .REXP value = 2;
+  inline bool has_value() const;
+  inline void clear_value();
+  static const int kValueFieldNumber = 2;
+  inline const ::REXP& value() const;
+  inline ::REXP* mutable_value();
+  inline ::REXP* release_value();
+  inline void set_allocated_value(::REXP* value);
+
+  // @@protoc_insertion_point(class_scope:ENV)
+ private:
+  inline void set_has_key();
+  inline void clear_has_key();
+  inline void set_has_value();
+  inline void clear_has_value();
+
+  ::google::protobuf::UnknownFieldSet _unknown_fields_;
+
+  ::std::string* key_;
+  ::REXP* value_;
+
+  mutable int _cached_size_;
+  ::google::protobuf::uint32 _has_bits_[(2 + 31) / 32];
+
+  friend void  protobuf_AddDesc_rexp_2eproto();
+  friend void protobuf_AssignDesc_rexp_2eproto();
+  friend void protobuf_ShutdownFile_rexp_2eproto();
+
+  void InitAsDefaultInstance();
+  static ENV* default_instance_;
 };
 // -------------------------------------------------------------------
 
@@ -855,6 +964,143 @@ REXP::attrvalue() const {
 inline ::google::protobuf::RepeatedPtrField< ::REXP >*
 REXP::mutable_attrvalue() {
   return &attrvalue_;
+}
+
+// repeated .ENV envValue = 13;
+inline int REXP::envvalue_size() const {
+  return envvalue_.size();
+}
+inline void REXP::clear_envvalue() {
+  envvalue_.Clear();
+}
+inline const ::ENV& REXP::envvalue(int index) const {
+  return envvalue_.Get(index);
+}
+inline ::ENV* REXP::mutable_envvalue(int index) {
+  return envvalue_.Mutable(index);
+}
+inline ::ENV* REXP::add_envvalue() {
+  return envvalue_.Add();
+}
+inline const ::google::protobuf::RepeatedPtrField< ::ENV >&
+REXP::envvalue() const {
+  return envvalue_;
+}
+inline ::google::protobuf::RepeatedPtrField< ::ENV >*
+REXP::mutable_envvalue() {
+  return &envvalue_;
+}
+
+// -------------------------------------------------------------------
+
+// ENV
+
+// optional string key = 1;
+inline bool ENV::has_key() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void ENV::set_has_key() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void ENV::clear_has_key() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void ENV::clear_key() {
+  if (key_ != &::google::protobuf::internal::kEmptyString) {
+    key_->clear();
+  }
+  clear_has_key();
+}
+inline const ::std::string& ENV::key() const {
+  return *key_;
+}
+inline void ENV::set_key(const ::std::string& value) {
+  set_has_key();
+  if (key_ == &::google::protobuf::internal::kEmptyString) {
+    key_ = new ::std::string;
+  }
+  key_->assign(value);
+}
+inline void ENV::set_key(const char* value) {
+  set_has_key();
+  if (key_ == &::google::protobuf::internal::kEmptyString) {
+    key_ = new ::std::string;
+  }
+  key_->assign(value);
+}
+inline void ENV::set_key(const char* value, size_t size) {
+  set_has_key();
+  if (key_ == &::google::protobuf::internal::kEmptyString) {
+    key_ = new ::std::string;
+  }
+  key_->assign(reinterpret_cast<const char*>(value), size);
+}
+inline ::std::string* ENV::mutable_key() {
+  set_has_key();
+  if (key_ == &::google::protobuf::internal::kEmptyString) {
+    key_ = new ::std::string;
+  }
+  return key_;
+}
+inline ::std::string* ENV::release_key() {
+  clear_has_key();
+  if (key_ == &::google::protobuf::internal::kEmptyString) {
+    return NULL;
+  } else {
+    ::std::string* temp = key_;
+    key_ = const_cast< ::std::string*>(&::google::protobuf::internal::kEmptyString);
+    return temp;
+  }
+}
+inline void ENV::set_allocated_key(::std::string* key) {
+  if (key_ != &::google::protobuf::internal::kEmptyString) {
+    delete key_;
+  }
+  if (key) {
+    set_has_key();
+    key_ = key;
+  } else {
+    clear_has_key();
+    key_ = const_cast< ::std::string*>(&::google::protobuf::internal::kEmptyString);
+  }
+}
+
+// optional .REXP value = 2;
+inline bool ENV::has_value() const {
+  return (_has_bits_[0] & 0x00000002u) != 0;
+}
+inline void ENV::set_has_value() {
+  _has_bits_[0] |= 0x00000002u;
+}
+inline void ENV::clear_has_value() {
+  _has_bits_[0] &= ~0x00000002u;
+}
+inline void ENV::clear_value() {
+  if (value_ != NULL) value_->::REXP::Clear();
+  clear_has_value();
+}
+inline const ::REXP& ENV::value() const {
+  return value_ != NULL ? *value_ : *default_instance_->value_;
+}
+inline ::REXP* ENV::mutable_value() {
+  set_has_value();
+  if (value_ == NULL) value_ = new ::REXP;
+  return value_;
+}
+inline ::REXP* ENV::release_value() {
+  clear_has_value();
+  ::REXP* temp = value_;
+  value_ = NULL;
+  return temp;
+}
+inline void ENV::set_allocated_value(::REXP* value) {
+  delete value_;
+  value_ = value;
+  if (value) {
+    set_has_value();
+  } else {
+    clear_has_value();
+  }
 }
 
 // -------------------------------------------------------------------

--- a/src/main/C/rexp.proto
+++ b/src/main/C/rexp.proto
@@ -10,10 +10,10 @@ message REXP {
     LIST	= 5;
     LOGICAL	= 6;
     NULLTYPE	= 7;
-    REAL1       = 8;
-    INTEGER1    = 10;
-    STRING1     = 9;
-
+//    REAL1       = 8;
+//    INTEGER1    = 10;
+//    STRING1     = 9;
+    ENVIRONMENT = 8;
   }
   enum RBOOLEAN {
     F	= 0;
@@ -31,9 +31,14 @@ message REXP {
   repeated REXP	    rexpValue		= 8;
   repeated string   attrName		= 11;
   repeated REXP     attrValue		= 12;
-
+  repeated ENV      envValue		= 13;
 }
 
+
+message ENV {
+	optional string key = 1;
+ 	optional REXP  value = 2;
+}
 
 message STRING {
   optional string strval = 1;

--- a/src/main/C/rhooks.cc
+++ b/src/main/C/rhooks.cc
@@ -56,7 +56,7 @@ SEXP unserializeUsingPB(SEXP robj) {
 	//     rexp_container->Clear();
 	CodedInputStream cds(RAW(robj), LENGTH(robj));
 	// rexp_container->ParseFromArray(RAW(robj),LENGTH(robj));
-	cds.SetTotalBytesLimit(2*1024 * 1024 * 1024-50, 1.5*1024 * 1024 * 1024);
+	cds.SetTotalBytesLimit(512*1024 * 1024, 250*1024 * 1024);
 	rexp_container->ParseFromCodedStream(&cds);
 	PROTECT(ans = rexpToSexp(*rexp_container));
 	UNPROTECT(1);
@@ -416,7 +416,7 @@ void writeKeyValues32(FILE* fout, SEXP vkeyvalues, uint32_t buffer_size){
  */
 SEXP writeBinaryFile(SEXP vkeyvalues, SEXP sfilename, SEXP nbuffer_size) {
 	char *filename = (char*) CHAR(STRING_ELT( sfilename , 0));
-	uint32_t buffer_size = INTEGER(nbuffer_size)[0], m = buffer_size;
+	uint32_t buffer_size = INTEGER(nbuffer_size)[0];
 	FILE *fp = fopen(filename, "w");
 	setvbuf(fp, NULL, _IOFBF, 0);
 	writeKeyValues32(fp,vkeyvalues,buffer_size);


### PR DESCRIPTION
Environments created via new.env(). Only the keys and values will be serialized (and deserialized). Parents, frames etc are ignored. Attributes are preserved.
I haven't changed the version numbers.