### PR TITLE
Fixed github issue 34

### DIFF
--- a/src/main/C/reducer.cc
+++ b/src/main/C/reducer.cc
@@ -121,7 +121,7 @@ const int reducer_run(void){
       if(redbuf_cnt == REDBUFFER){
 	// Case 1. The reduce.values has reached the critical length
 	// for evaluation
-	Rf_setVar(Rf_install("reduce.values"),vvector,R_GlobalEnv);
+	Rf_setVar(Rf_install("reduce.values"),Rf_duplicate(vvector),R_GlobalEnv);
 	WRAP_R_EVAL(reduce,NULL, &Rerr);
 	redbuf_cnt=0;
 	bytes_read = 0;


### PR DESCRIPTION
When vvector is set to reduce.valus and reduce.values added to adata (in the example Ryan provided) R was not copying reduce.values.  Back in the C code with the next call to reduce$reduce vvector (whcih backed reduce.values)  was getting overwritten.
